### PR TITLE
Preserve line numbers in errors and show file name.

### DIFF
--- a/Assembler/tests/bad/includes/a.asm
+++ b/Assembler/tests/bad/includes/a.asm
@@ -1,0 +1,2 @@
+add r8, r9, r10
+#include <b.asm>

--- a/Assembler/tests/bad/includes/b.asm
+++ b/Assembler/tests/bad/includes/b.asm
@@ -1,0 +1,1 @@
+bra dontexist

--- a/Assembler/tests/includes.asm
+++ b/Assembler/tests/includes.asm
@@ -1,3 +1,0 @@
-#include <included.asm>
-
-bra foo


### PR DESCRIPTION
For example, I added `a.asm` which includes `b.asm` and `b.asm` tries to
jump to a label that does not exist. The resultant error looks like

```
Address dontexist is not defined

File b.asm, line 1:
bra dontexist
```